### PR TITLE
Issue 1

### DIFF
--- a/docs/source/api_methods.rst
+++ b/docs/source/api_methods.rst
@@ -55,7 +55,6 @@ bbox_inches      None            [None | 'tight' | float] Bbox in inches. Only
 cbar_label       'z'             [str] Label of the contour plot color bar
 cbar_ticks       None            [None | int | np.ndarray] Set the color bar ticks
 cbar_tick_format '%.2f'          [str] Print format of the color bar ticks
-contours         7               [int] Number of contour levels
 crop             True            [True | False] Crops images before encoding
 dpi              None            [None | int] DPI of saved images. Defaults to
                                  savefig.dpi value in matplotlibrc file.
@@ -71,6 +70,9 @@ img_fmt          'png'           ['png' | 'jpg' | 'bmp'] Films can only be made
                                  using these image formats. *pyfilm* will write
                                  frames for any image format that Matplotlib
                                  supports and print a warning.
+ncontours        11              [int] Number of contours used in 2D plots.
+                                 Ignored when ``levels`` is specified in
+                                 ``plot_options``.
 nprocs           None            [None | int] Set max number of cpu cores to
                                  use. Defaults to max number of cores on
                                  machine.

--- a/pyfilm/pyfilm.py
+++ b/pyfilm/pyfilm.py
@@ -153,8 +153,6 @@ def make_film_2d(*args, **kwargs):
     except KeyError:
         plot_options = calculate_contours(z, options, plot_options)
 
-    print(plot_options)
-
     if type(options['cbar_ticks']) == np.ndarray:
         pass
     elif type(options['cbar_ticks']) == int or options['cbar_ticks'] == None:

--- a/pyfilm/pyfilm.py
+++ b/pyfilm/pyfilm.py
@@ -41,14 +41,12 @@ def make_film_1d(*args, **kwargs):
 
     options = {}
     options = set_default_options(options)
-    try:
+    if 'options' in kwargs:
         options = set_user_options(options, kwargs['options'])
-    except KeyError:
-        pass
 
-    try:
+    if 'plot_options' in kwargs:
         plot_options = kwargs['plot_options']
-    except KeyError:
+    else:
         plot_options = {}
 
     set_up_dirs(options)
@@ -110,14 +108,12 @@ def make_film_2d(*args, **kwargs):
     """
     options = {}
     options = set_default_options(options)
-    try:
+    if 'options' in kwargs:
         options = set_user_options(options, kwargs['options'])
-    except KeyError:
-        pass
 
-    try:
+    if 'plot_options' in kwargs:
         plot_options = kwargs['plot_options']
-    except KeyError:
+    else:
         plot_options = {}
 
     set_up_dirs(options)
@@ -147,10 +143,7 @@ def make_film_2d(*args, **kwargs):
     else:
         raise ValueError('This function only takes in max. 3 arguments.')
 
-    try:
-        if plot_options['levels']:
-            pass
-    except KeyError:
+    if 'levels' not in plot_options:
         plot_options = calculate_contours(z, options, plot_options)
 
     if type(options['cbar_ticks']) == np.ndarray:

--- a/tests/test_pyfilm.py
+++ b/tests/test_pyfilm.py
@@ -28,6 +28,7 @@ class TestClass(object):
         assert options['file_name'] == 'f'
         assert options['grid'] == False
         assert options['img_fmt'] == 'png'
+        assert options['ncontours'] == 11
         assert type(options['nprocs']) == int
         assert options['title'] == ''
         assert options['video_fmt'] == 'mp4'
@@ -192,7 +193,6 @@ class TestClass(object):
         assert len(options['title']) == 10
 
         options['title'] = ['test']*9
-
         pytest.raises(ValueError, "make_plot_titles(10, options)")
 
     def test_img_fmt(self):
@@ -201,3 +201,65 @@ class TestClass(object):
         make_film_1d(x, y, options={'img_fmt':'jpg'})
         assert ('f_00000.jpg' in os.listdir('films/film_frames/'))
         assert ('f.mp4' in os.listdir('films/'))
+
+    def test_calculate_cbar_ticks(self):
+        options = {}
+        options = set_default_options(options)
+        z = np.random.randint(low=0, high=2, size=[2,2,2])
+        options = calculate_cbar_ticks(z, options)
+        assert np.sum(options['cbar_ticks'] - np.linspace(0, 1, 5)) < 1e-5
+
+        options = {}
+        options = set_default_options(options)
+        options['cbar_ticks'] = 7
+        z = np.random.randint(low=0, high=2, size=[2,2,2])
+        options = calculate_cbar_ticks(z, options)
+        assert np.sum(options['cbar_ticks'] - np.linspace(0, 1, 7)) < 1e-5
+
+    def test_calculate_contours(self):
+        options = {}
+        options = set_default_options(options)
+        plot_options = {}
+        z = np.random.randint(low=0, high=2, size=[2,2,2])
+        options = calculate_contours(z, options, plot_options)
+        assert np.sum(plot_options['levels'] - np.linspace(0, 1, 11)) < 1e-5
+
+        options = {}
+        options = set_default_options(options)
+        plot_options = {}
+        z = np.random.randint(low=-1, high=2, size=[2,2,2])
+        options = calculate_contours(z, options, plot_options)
+        assert np.sum(plot_options['levels'] - np.linspace(-1, 1, 11)) < 1e-5
+
+        options = {}
+        options = set_default_options(options)
+        plot_options = {}
+        z = np.random.randint(low=-2, high=1, size=[2,2,2])
+        options = calculate_contours(z, options, plot_options)
+        assert np.sum(plot_options['levels'] - np.linspace(-2, 0, 11)) < 1e-5
+
+        options = {}
+        options = set_default_options(options)
+        options['ncontours'] = 21
+        plot_options = {}
+        z = np.random.randint(low=0, high=2, size=[2,2,2])
+        options = calculate_contours(z, options, plot_options)
+        assert np.sum(plot_options['levels'] - np.linspace(0, 1, 21)) < 1e-5
+
+        options = {}
+        options = set_default_options(options)
+        options['ncontours'] = 21
+        plot_options = {}
+        z = np.random.randint(low=-1, high=2, size=[2,2,2])
+        options = calculate_contours(z, options, plot_options)
+        assert np.sum(plot_options['levels'] - np.linspace(-1, 1, 21)) < 1e-5
+
+        options = {}
+        options = set_default_options(options)
+        options['ncontours'] = 21
+        plot_options = {}
+        z = np.random.randint(low=-2, high=1, size=[2,2,2])
+        options = calculate_contours(z, options, plot_options)
+        assert np.sum(plot_options['levels'] - np.linspace(-2, 0, 21)) < 1e-5
+
+

--- a/tests/test_pyfilm.py
+++ b/tests/test_pyfilm.py
@@ -220,46 +220,16 @@ class TestClass(object):
         options = {}
         options = set_default_options(options)
         plot_options = {}
-        z = np.random.randint(low=0, high=2, size=[2,2,2])
+        z = np.reshape(np.arange(8), [2,2,2])
         options = calculate_contours(z, options, plot_options)
-        assert np.sum(plot_options['levels'] - np.linspace(0, 1, 11)) < 1e-5
-
-        options = {}
-        options = set_default_options(options)
-        plot_options = {}
-        z = np.random.randint(low=-1, high=2, size=[2,2,2])
-        options = calculate_contours(z, options, plot_options)
-        assert np.sum(plot_options['levels'] - np.linspace(-1, 1, 11)) < 1e-5
-
-        options = {}
-        options = set_default_options(options)
-        plot_options = {}
-        z = np.random.randint(low=-2, high=1, size=[2,2,2])
-        options = calculate_contours(z, options, plot_options)
-        assert np.sum(plot_options['levels'] - np.linspace(-2, 0, 11)) < 1e-5
+        assert np.sum(plot_options['levels'] - np.linspace(0, 7, 11)) < 1e-5
 
         options = {}
         options = set_default_options(options)
         options['ncontours'] = 21
         plot_options = {}
-        z = np.random.randint(low=0, high=2, size=[2,2,2])
+        z = np.reshape(np.arange(8), [2,2,2])
         options = calculate_contours(z, options, plot_options)
-        assert np.sum(plot_options['levels'] - np.linspace(0, 1, 21)) < 1e-5
-
-        options = {}
-        options = set_default_options(options)
-        options['ncontours'] = 21
-        plot_options = {}
-        z = np.random.randint(low=-1, high=2, size=[2,2,2])
-        options = calculate_contours(z, options, plot_options)
-        assert np.sum(plot_options['levels'] - np.linspace(-1, 1, 21)) < 1e-5
-
-        options = {}
-        options = set_default_options(options)
-        options['ncontours'] = 21
-        plot_options = {}
-        z = np.random.randint(low=-2, high=1, size=[2,2,2])
-        options = calculate_contours(z, options, plot_options)
-        assert np.sum(plot_options['levels'] - np.linspace(-2, 0, 21)) < 1e-5
+        assert np.sum(plot_options['levels'] - np.linspace(0, 7, 21)) < 1e-5
 
 


### PR DESCRIPTION
Resolve issue #1 

- Added `ncontours` variable with default value 11 (odd numbers work best for colour ranges that both negative and positive, if not it doesn't matter)
- Removed `contours` variable
- Clean up error logic for checking existence of options
- Additional tests and documentation

New functionality as follows:

- If nothing specified, pyfilm determines extrema of array and calculates 11 contour levels and sets this as `plot_options['levels']`, which is a matplotlib variable.
- If `ncontours` specified, will do the above with a given number of contours.
- If `levels` specified in plot_options, this overrides the above and is passed directly to matplotlib.